### PR TITLE
Adicionando a superclasse ItemGeral

### DIFF
--- a/src/br/edu/insper/desagil/alfandega/Alfandega.java
+++ b/src/br/edu/insper/desagil/alfandega/Alfandega.java
@@ -4,42 +4,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Alfandega {
-	private List<Item> itens;
-	private List<ItemTarifado> itensTarifados;
+	private List<ItemGeral> itens;
 
 	public Alfandega() {
 		this.itens = new ArrayList<>();
-		this.itensTarifados = new ArrayList<>();
 	}
 
-	public void declara(Item item) {
+	public void declara(ItemGeral item) {
 		this.itens.add(item);
-	}
-
-	public void declara(ItemTarifado itemTarifado) {
-		this.itensTarifados.add(itemTarifado);
 	}
 
 	public double getTotalDeclarado() {
 		double total = 0.0;
-		for (Item item : this.itens) {
+		for (ItemGeral item : this.itens) {
 			total += item.getRate() * item.getValor();
-		}
-		for (ItemTarifado itemTarifado : this.itensTarifados) {
-			total += itemTarifado.getRate() * itemTarifado.getValor();
 		}
 		return total;
 	}
 
 	public double getTotalDevido() {
 		double total = 0.0;
-		for (Item item : this.itens) {
+		for (ItemGeral item : this.itens) {
 			// Mesmo em itens sem tarifa, a alfândega cobra
 			// uma taxa de 1% Por quê? Porque eles podem.
-			total += item.getRate() * item.getValor() * 0.01;
-		}
-		for (ItemTarifado itemTarifado : this.itensTarifados) {
-			total += itemTarifado.getRate() * itemTarifado.getValor() * itemTarifado.getTarifa();
+			total += item.getRate() * item.getValor() * item.getTarifa();
 		}
 		return total;
 	}

--- a/src/br/edu/insper/desagil/alfandega/Item.java
+++ b/src/br/edu/insper/desagil/alfandega/Item.java
@@ -1,6 +1,6 @@
 package br.edu.insper.desagil.alfandega;
 
-public class Item {
+public class Item extends ItemGeral {
 	private String nome;
 	private double valor;
 	private double rate;
@@ -15,11 +15,18 @@ public class Item {
 		return this.nome;
 	}
 
+	@Override
 	public double getValor() {
 		return this.valor;
 	}
 
+	@Override
 	public double getRate() {
 		return this.rate;
+	}
+	
+	@Override
+	public double getTarifa() {
+		return 0.01;
 	}
 }

--- a/src/br/edu/insper/desagil/alfandega/ItemGeral.java
+++ b/src/br/edu/insper/desagil/alfandega/ItemGeral.java
@@ -1,0 +1,10 @@
+package br.edu.insper.desagil.alfandega;
+
+public abstract class ItemGeral {
+	
+	public abstract double getValor();
+	
+	public abstract double getTarifa();
+
+	public abstract double getRate();
+}

--- a/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
+++ b/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
@@ -1,6 +1,6 @@
 package br.edu.insper.desagil.alfandega;
 
-public class ItemTarifado {
+public class ItemTarifado extends ItemGeral{
 	private String nome;
 	private double valor;
 	private double rate;
@@ -17,14 +17,17 @@ public class ItemTarifado {
 		return this.nome;
 	}
 
+	@Override
 	public double getValor() {
 		return this.valor;
 	}
 
+	@Override
 	public double getRate() {
 		return this.rate;
 	}
 
+	@Override
 	public double getTarifa() {
 		return this.tarifa;
 	}


### PR DESCRIPTION
Esta modificação adiciona a superclasse ItemGeral. Essa superclasse é uma abstração de um conceito geral dos itens da alfândega que precisam ter um valor, um rate e o que foi chamado de tarifa, que para o caso dos itens tarifados é um valor específico deles e para o caso do item este valor é de 0.01. 

Essa abstração permitiu que duas listas de itens do objeto Alfandega pudessem ser substituídas por apenas uma, o que reduz a repetição do código principalmente para os métodos getTotalDeclarado() e getTotalDevido().

Além disso, deixa o código preparado para outros possíveis itens que possam ser adicionados futuramente. 