### PR TITLE
Add Superclass "Item"

### DIFF
--- a/src/br/edu/insper/desagil/alfandega/Alfandega.java
+++ b/src/br/edu/insper/desagil/alfandega/Alfandega.java
@@ -5,19 +5,13 @@ import java.util.List;
 
 public class Alfandega {
 	private List<Item> itens;
-	private List<ItemTarifado> itensTarifados;
 
 	public Alfandega() {
 		this.itens = new ArrayList<>();
-		this.itensTarifados = new ArrayList<>();
 	}
 
 	public void declara(Item item) {
 		this.itens.add(item);
-	}
-
-	public void declara(ItemTarifado itemTarifado) {
-		this.itensTarifados.add(itemTarifado);
 	}
 
 	public double getTotalDeclarado() {
@@ -25,21 +19,13 @@ public class Alfandega {
 		for (Item item : this.itens) {
 			total += item.getRate() * item.getValor();
 		}
-		for (ItemTarifado itemTarifado : this.itensTarifados) {
-			total += itemTarifado.getRate() * itemTarifado.getValor();
-		}
 		return total;
 	}
 
 	public double getTotalDevido() {
 		double total = 0.0;
 		for (Item item : this.itens) {
-			// Mesmo em itens sem tarifa, a alfândega cobra
-			// uma taxa de 1% Por quê? Porque eles podem.
-			total += item.getRate() * item.getValor() * 0.01;
-		}
-		for (ItemTarifado itemTarifado : this.itensTarifados) {
-			total += itemTarifado.getRate() * itemTarifado.getValor() * itemTarifado.getTarifa();
+			total += item.getRate() * item.getPreco();
 		}
 		return total;
 	}

--- a/src/br/edu/insper/desagil/alfandega/Item.java
+++ b/src/br/edu/insper/desagil/alfandega/Item.java
@@ -1,16 +1,17 @@
 package br.edu.insper.desagil.alfandega;
 
-public class Item {
+public abstract class Item {
 	private String nome;
 	private double valor;
 	private double rate;
-
+	
 	public Item(String nome, double valor, double rate) {
+		super();
 		this.nome = nome;
 		this.valor = valor;
 		this.rate = rate;
 	}
-
+	
 	public String getNome() {
 		return this.nome;
 	}
@@ -22,4 +23,7 @@ public class Item {
 	public double getRate() {
 		return this.rate;
 	}
+
+	public abstract double getPreco();
+	
 }

--- a/src/br/edu/insper/desagil/alfandega/ItemSemTarifa.java
+++ b/src/br/edu/insper/desagil/alfandega/ItemSemTarifa.java
@@ -1,0 +1,16 @@
+package br.edu.insper.desagil.alfandega;
+
+public class ItemSemTarifa extends Item {
+	
+	public ItemSemTarifa(String nome, double valor, double rate) {
+		super(nome, valor, rate);
+	}
+	
+	@Override
+	public double getPreco() {
+		// Mesmo em itens sem tarifa, a alfândega cobra
+		// uma taxa de 1% Por quê? Porque eles podem.
+		return super.getValor() * 0.01;
+	}
+	
+}

--- a/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
+++ b/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
@@ -1,31 +1,16 @@
 package br.edu.insper.desagil.alfandega;
 
-public class ItemTarifado {
-	private String nome;
-	private double valor;
-	private double rate;
+public class ItemTarifado extends Item {
 	private double tarifa;
 
 	public ItemTarifado(String nome, double valor, double rate, double tarifa) {
-		this.nome = nome;
-		this.valor = valor;
-		this.rate = rate;
+		super(nome, valor, rate);
 		this.tarifa = tarifa;
 	}
 
-	public String getNome() {
-		return this.nome;
+	@Override
+	public double getPreco() {
+		return super.getValor() * this.tarifa;
 	}
-
-	public double getValor() {
-		return this.valor;
-	}
-
-	public double getRate() {
-		return this.rate;
-	}
-
-	public double getTarifa() {
-		return this.tarifa;
-	}
+	
 }

--- a/test/br/edu/insper/desagil/alfandega/AlfandegaTest.java
+++ b/test/br/edu/insper/desagil/alfandega/AlfandegaTest.java
@@ -17,23 +17,23 @@ class AlfandegaTest {
 
 	@Test
 	void testA() {
-		alfandega.declara(new Item("a", 25.0, 5.12));
-		alfandega.declara(new Item("b", 50.0, 6.19));
+		alfandega.declara(new ItemSemTarifa("a", 25.0, 5.12));
+		alfandega.declara(new ItemSemTarifa("b", 50.0, 6.19));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(4.38, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testB() {
-		alfandega.declara(new Item("a", 50.0, 5.12));
-		alfandega.declara(new Item("b", 25.0, 6.19));
+		alfandega.declara(new ItemSemTarifa("a", 50.0, 5.12));
+		alfandega.declara(new ItemSemTarifa("b", 25.0, 6.19));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(4.11, alfandega.getTotalDevido(), DELTA);
 	}
 
 	@Test
 	void testC() {
-		alfandega.declara(new Item("a", 25.0, 5.12));
+		alfandega.declara(new ItemSemTarifa("a", 25.0, 5.12));
 		alfandega.declara(new ItemTarifado("b", 50.0, 6.19, 0.6));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(186.98, alfandega.getTotalDevido(), DELTA);
@@ -41,7 +41,7 @@ class AlfandegaTest {
 
 	@Test
 	void testD() {
-		alfandega.declara(new Item("a", 50.0, 5.12));
+		alfandega.declara(new ItemSemTarifa("a", 50.0, 5.12));
 		alfandega.declara(new ItemTarifado("b", 25.0, 6.19, 0.6));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(95.41, alfandega.getTotalDevido(), DELTA);
@@ -50,7 +50,7 @@ class AlfandegaTest {
 	@Test
 	void testE() {
 		alfandega.declara(new ItemTarifado("a", 25.0, 5.12, 0.6));
-		alfandega.declara(new Item("b", 50.0, 6.19));
+		alfandega.declara(new ItemSemTarifa("b", 50.0, 6.19));
 		assertEquals(437.5, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(79.9, alfandega.getTotalDevido(), DELTA);
 	}
@@ -58,7 +58,7 @@ class AlfandegaTest {
 	@Test
 	void testF() {
 		alfandega.declara(new ItemTarifado("a", 50.0, 5.12, 0.6));
-		alfandega.declara(new Item("b", 25.0, 6.19));
+		alfandega.declara(new ItemSemTarifa("b", 25.0, 6.19));
 		assertEquals(410.75, alfandega.getTotalDeclarado(), DELTA);
 		assertEquals(155.15, alfandega.getTotalDevido(), DELTA);
 	}


### PR DESCRIPTION
Este commit adiciona a superclasse Item que abstrai o conceito de item, sem diferenciar se é tarifado ou não.

Desse modo, evita a repetição de código, permitindo que a classe Alfandega possua apenas uma lista de itens, o que por sua vez evita repetição de código em seus métodos "declara", "getTotalDeclarado" e "getTotalDevido".

Como resultado da superclasse, o código fica preparado caso fosse de interesse a implementação de um novo tipo de item futuramente.

