### PR TITLE
ItemTarifado agora é subclasse de Item

### DIFF
--- a/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
+++ b/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
@@ -1,28 +1,12 @@
 package br.edu.insper.desagil.alfandega;
 
-public class ItemTarifado {
-	private String nome;
-	private double valor;
-	private double rate;
+public class ItemTarifado extends Item {
+	
 	private double tarifa;
-
-	public ItemTarifado(String nome, double valor, double rate, double tarifa) {
-		this.nome = nome;
-		this.valor = valor;
-		this.rate = rate;
-		this.tarifa = tarifa;
-	}
-
-	public String getNome() {
-		return this.nome;
-	}
-
-	public double getValor() {
-		return this.valor;
-	}
-
-	public double getRate() {
-		return this.rate;
+	
+	public ItemTarifado(String nome, double valor, double rate,double tarifa) {
+		super(nome, valor, rate);
+		this.tarifa=tarifa;
 	}
 
 	public double getTarifa() {


### PR DESCRIPTION
Uma oportunidade de melhoria no codigo que foi feita nesse commit foi a de abstração, a classe "ItemTarifado" antes independente agora é subclasse de Item. Isso foi feito justamente por ambas apresentarem os mesmos atributos e métodos exceto o método "getTarifa". Portanto faz sentido a aplicação de subclasse porque ItemTarifado é um caso especifico de Item (sendo Item tarifado um Item com uma tarifa aplicada sobre ele). 