### PR TITLE
Item como superclasse de ItemTarifado

### DIFF
--- a/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
+++ b/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
@@ -1,28 +1,11 @@
 package br.edu.insper.desagil.alfandega;
 
-public class ItemTarifado {
-	private String nome;
-	private double valor;
-	private double rate;
+public class ItemTarifado extends Item{
 	private double tarifa;
 
 	public ItemTarifado(String nome, double valor, double rate, double tarifa) {
-		this.nome = nome;
-		this.valor = valor;
-		this.rate = rate;
+		super(nome, valor, rate);
 		this.tarifa = tarifa;
-	}
-
-	public String getNome() {
-		return this.nome;
-	}
-
-	public double getValor() {
-		return this.valor;
-	}
-
-	public double getRate() {
-		return this.rate;
 	}
 
 	public double getTarifa() {


### PR DESCRIPTION
Esta modificação adiciona a classe Item como superclasse de ItemTarifado. Foi realizada este modificação com o fim de representar o ItemTarifado como um caso particular da classe Item.

Pode-se considerar uma oportunidade de abstração (uso de uma superclasse para representar características em comum).

Com as devidas alterações feitas, em mudanças futuras, será mais fácil adicionar eventuais novas características à classe ItemTarifado e, ao mesmo tempo, melhorar a abstração do projeto como um todo.
