### PR TITLE
Item se tornou superclasse de ItemTarifado

### DIFF
--- a/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
+++ b/src/br/edu/insper/desagil/alfandega/ItemTarifado.java
@@ -1,30 +1,13 @@
 package br.edu.insper.desagil.alfandega;
 
-public class ItemTarifado {
-	private String nome;
-	private double valor;
-	private double rate;
+public class ItemTarifado extends Item {
+	
 	private double tarifa;
 
 	public ItemTarifado(String nome, double valor, double rate, double tarifa) {
-		this.nome = nome;
-		this.valor = valor;
-		this.rate = rate;
+		super(nome,valor,rate);
 		this.tarifa = tarifa;
 	}
-
-	public String getNome() {
-		return this.nome;
-	}
-
-	public double getValor() {
-		return this.valor;
-	}
-
-	public double getRate() {
-		return this.rate;
-	}
-
 	public double getTarifa() {
 		return this.tarifa;
 	}


### PR DESCRIPTION
As classes Item e ItemTarifado tinham algumas propriedades em comum. Vale notar que todas as propriedades de Item (nome, valor, rate) estavam sendo utilizadas em ItemComum. Dessa forma foi identificada um oportunidade de abstração de fazer Item ser uma superclasse de ItemTarifado.